### PR TITLE
Build user on demand

### DIFF
--- a/MyLocalBooking/app/src/main/java/uni/project/mylocalbooking/MyLocalBooking.java
+++ b/MyLocalBooking/app/src/main/java/uni/project/mylocalbooking/MyLocalBooking.java
@@ -3,8 +3,17 @@ package uni.project.mylocalbooking;
 import android.app.Application;
 import android.content.Context;
 
+import java.time.LocalDate;
+import java.util.Map;
+
+import uni.project.mylocalbooking.models.AppUser;
+import uni.project.mylocalbooking.models.Client;
+import uni.project.mylocalbooking.models.Coordinates;
+import uni.project.mylocalbooking.models.Provider;
+
 public class MyLocalBooking extends Application {
     private static Context context;
+    private static AppUser currentUser;
 
     public void onCreate() {
         super.onCreate();
@@ -13,5 +22,37 @@ public class MyLocalBooking extends Application {
 
     public static Context getAppContext() {
         return MyLocalBooking.context;
+    }
+
+    private static AppUser buildCurrentUser() {
+        Map<String, ?> prefs = SessionPreferences.getUserPrefs();
+        Long id = (Long) prefs.get("id");
+        String cellphone = (String) prefs.get("cellphone");
+        String firstname = (String) prefs.get("firstname");
+        String lastname = (String) prefs.get("lastname");
+        String email = (String) prefs.get("email");
+        Long subclassId = (Long) prefs.get("subclass_id");
+        LocalDate dob = LocalDate.ofEpochDay((Long) prefs.get("dob"));
+
+        if(((String) prefs.get("usertype")).equals("client")) {
+            Float lat = (Float) prefs.get("lat");
+            Float lng = (Float) prefs.get("lng");
+
+            Coordinates coordinates = lat == null || lng == null ? null : new Coordinates(lat, lng);
+            currentUser = new Client(subclassId, coordinates, id, cellphone, email, firstname, lastname, dob);
+        }
+        else {
+            Boolean verified = (Boolean) prefs.get("verified");
+            String company = (String) prefs.get("companyname");
+            Integer maxStrikes = (Integer) prefs.get("maxstrikes");
+
+            currentUser = new Provider(subclassId, verified, company, maxStrikes, null, id, cellphone, email, firstname, lastname, dob);
+        }
+
+        return currentUser;
+    }
+
+    public static AppUser getCurrentUser() {
+        return currentUser == null ? buildCurrentUser() : currentUser;
     }
 }

--- a/MyLocalBooking/app/src/main/java/uni/project/mylocalbooking/SessionPreferences.java
+++ b/MyLocalBooking/app/src/main/java/uni/project/mylocalbooking/SessionPreferences.java
@@ -29,18 +29,23 @@ public class SessionPreferences {
         try {
             SharedPreferences.Editor editor = getEditor();
             if(user.getId() != null)
-                editor.putInt("id", Math.toIntExact(user.getId()));
+                editor.putLong("id", user.getId());
             editor.putString("cellphone", user.cellphone);
-            editor.putString("username", user.firstname);
+            editor.putString("firstname", user.firstname);
             editor.putString("lastname", user.lastname);
+            editor.putString("email", user.email);
+            editor.putLong("dob", user.dob.toEpochDay());
 
             if(user instanceof Client){
                 Client client = (Client) user;
+                editor.putLong("subclass_id", client.getSubclassId());
                 editor.putString("usertype", "client");
                 editor.putFloat("lat", client.position.latitude);
                 editor.putFloat("lng", client.position.longitude);
             }else if(user instanceof Provider){
                 Provider provider = (Provider) user;
+                editor.putLong("subclass_id", provider.getSubclassId());
+                editor.putBoolean("verified", provider.verified);
                 editor.putString("usertype", "provider");
                 editor.putString("companyname", provider.companyName);
                 editor.putInt("maxstrikes", provider.maxStrikes);


### PR DESCRIPTION
The strikedUsers field still needs to be populated with the relative API call.
When the getCurrentUser method gets invoked for the first time the object is created, cached and returned.
We might want the user to be cached in case it is a provider, so we can also cache their strikedUsers